### PR TITLE
exposing private variables through protection

### DIFF
--- a/src/Docnet/MATT.class.php
+++ b/src/Docnet/MATT.class.php
@@ -83,7 +83,7 @@ class MATT
      *
      * @param $str_event
      */
-    private function __construct($str_event)
+    protected function __construct($str_event)
     {
         $this->str_event = $str_event;
         $this->str_source = gethostname();
@@ -221,12 +221,62 @@ class MATT
     }
 
     /**
+     * Set a private var from outside scope
+     */
+    protected function set_source($str_source) {
+       $this->str_source = $str_source;
+    }
+    /**
+     * Set a private var from outside scope
+     */
+    protected function set_event($str_event) {
+       $this->str_event = $str_event;
+    }
+    /**
+     * Get a private var from outside scope
+     */
+    protected function get_source() {
+       return $this->str_source;
+    }
+    /**
+     * Get a private var from outside scope
+     */
+    protected function get_event() {
+       return $this->str_event;
+    }
+    /**
+     * Get a private var from outside scope
+     */
+    protected function get_every() {
+       return $this->str_every;
+    }
+    /**
+     * Get a private var from outside scope
+     */
+    protected function get_email() {
+       return $this->str_email;
+    }
+    /**
+     * Get a private var from outside scope
+     */
+    protected function get_sms() {
+       return $this->str_sms;
+    }
+
+    /**
+     * Private override
+     */
+    protected function set_sent() {
+       $this->bol_sent = true;
+    }
+
+    /**
      * Process any response data from Matt Daemon
      *
      * @param $str_response
      * @return bool
      */
-    private function process_response($str_response)
+    protected function process_response($str_response)
     {
         if (FALSE === $str_response) {
             trigger_error(__METHOD__ . '() comms error', E_USER_WARNING);


### PR DESCRIPTION
We're wrapping calls to MATT inside our own G4MMATT class already which deals with live or not checks to stop sending dev MATT calls to live.  One of our servers is also PHP 5.3.3 and can't file_get_contents() over http or access composer's autoloaders (which is another sad story).  

SO

I've made some methods protected and provided some getters / setters so our extended class can overwrite the send() method to use curl and still have access to the underlying params.

We can carry on using our fork of this but it seemed prudent to try and merge back in to master just in case anyone else needs to extend MATT like we've had to.