### PR TITLE
falling back to curl when file_get_contents fails

### DIFF
--- a/src/Docnet/MATT.class.php
+++ b/src/Docnet/MATT.class.php
@@ -35,6 +35,13 @@ class MATT
     const CANCEL = 'cancel';
 
     /**
+     * Appspot URL to post our MATTs to
+     *
+     * @var string
+     */
+    const MATT_URL = 'https://matt-daemon-eu.appspot.com/expect';
+
+    /**
      * Sent yet? We only want to do this once!
      *
      * @var bool
@@ -216,7 +223,23 @@ class MATT
         $this->bol_sent = TRUE;
 
         // Make the request
-        $str_response = @file_get_contents('https://matt-daemon-eu.appspot.com/expect', FALSE, stream_context_create($arr_opts));
+        $str_response = @file_get_contents(self::MATT_URL, FALSE, stream_context_create($arr_opts));
+
+        // fallback to curl if it's available
+        if (FALSE === $str_response && function_exists('curl_init')) {
+            $res_curl = curl_init();
+            curl_setopt_array($res_curl, array(
+               CURLOPT_URL => self::MATT_URL,
+               CURLOPT_FRESH_CONNECT => TRUE,
+               CURLOPT_HEADER => FALSE,
+               CURLOPT_POST => TRUE,
+               CURLOPT_SSL_VERIFYHOST => FALSE,
+               CURLOPT_RETURNTRANSFER => TRUE,
+               CURLOPT_POSTFIELDS => $arr_data
+            ));
+            $str_response = curl_exec($res_curl);
+        }
+
         return $this->process_response($str_response);
     }
 


### PR DESCRIPTION
As discussed - DB04 has problems with file_get_contents even though fopen is set to treat urls like files

This allows a fallback to curl if the function exists